### PR TITLE
Add support for REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ The top level of the configuration file looks like this:
       },
       "scheme": "https",
       "__snapName": "myUniqueSnapName",
-      "__snapType": "__REST""
+      "__snapType": "__REST"
     },
   ...
   ]
 }
 ```
 * The `snaps` entry needs to contain the `__snapName` key to uniquely identify the request. This name will be used to create a file with the snap result on disk.
-* It is possible to specify any `HTTP` header field with `httpHeaders`  key, the value of a header needs to be a string. This key is requeried. Use `"httpHeaders": {}` to specify no headers.
+* It is possible to specify any `HTTP` header field with `httpHeaders`  key, the value of a header needs to be a string. This key is not required.
 * The `body` key (not required) accepts arbitrary `JSON` and it will be used to set the body if the `HTTP` request.
 * `__snapType` specifies the type of request Kombucha is going to issue. `__REST"` is a simple HTTP `GET`, `POST`, `PUT`, `DELETE` or `PATCH` request (see the `httpMethod` key above), and the remaining parameters are interpreted accordingly: `queryItems` are converted into key-value pairs and appended onto the `path`, etc.
    * The `snaps` entry above results in an HTTP `GET` to `https://httpbin.org/response-headers?foo=1&bar=2&baz=3`. In addition, Kombucha always sends an `Accept` header of `application/json`.
@@ -77,9 +77,6 @@ The user can add a `__preferences` blob to their configuration file to specify e
     {
       "host": "httpbin.org",
       "httpMethod": "GET",
-      "httpHeaders": {
-        "Accept-Language": "en-US"  
-      },
       "path": "/response-headers",
       "queryItems": {},
       "scheme": "https",

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The top level of the configuration file looks like this:
 * The `snaps` entry needs to contain the `__snapName` key to uniquely identify the request. This name will be used to create a file with the snap result on disk.
 * It is possible to specify any `HTTP` header field with `httpHeaders`  key, the value of a header needs to be a string. This key is not required.
 * The `body` key (not required) accepts arbitrary `JSON` and it will be used to set the body if the `HTTP` request.
-* `__snapType` specifies the type of request Kombucha is going to issue. `__REST"` is a simple HTTP `GET`, `POST`, `PUT`, `DELETE` or `PATCH` request (see the `httpMethod` key above), and the remaining parameters are interpreted accordingly: `queryItems` are converted into key-value pairs and appended onto the `path`, etc.
+* `__snapType` specifies the type of request Kombucha is going to issue. The `__REST"` type represents a simple `HTTP` request. The `HTTP` method most be specified with the required `httpMethod` key, use `GET`, `POST`, `PUT`, `DELETE`, `PATCH` or any other methods as the value. The remaining parameters are interpreted accordingly: `queryItems` are converted into key-value pairs and appended onto the `path`, etc.
    * The `snaps` entry above results in an HTTP `GET` to `https://httpbin.org/response-headers?foo=1&bar=2&baz=3`. In addition, Kombucha always sends an `Accept` header of `application/json`.
 * Kombucha also supports a `__GRAPHQL` `__snapType` for testing GraphQL endpoints. Documentation for this is forthcoming. 😄
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The top level of the configuration file looks like this:
 }
 ```
 * The `snaps` entry needs to contain the `__snapName` key to uniquely identify the request. This name will be used to create a file with the snap result on disk.
-* It is possible to specify any `HTTP` header field with `httpHeaders`  key, the value of a header needs to be a string. This key is not required.
+* It is possible to specify any `HTTP` header field with the `httpHeaders` key, the value of a header needs to be a string. This key is not required.
 * The `body` key (not required) accepts arbitrary `JSON` and it will be used to set the body if the `HTTP` request.
 * `__snapType` specifies the type of request Kombucha is going to issue. The `__REST"` type represents a simple `HTTP` request. The `HTTP` method most be specified with the required `httpMethod` key, use `GET`, `POST`, `PUT`, `DELETE`, `PATCH` or any other methods as the value. The remaining parameters are interpreted accordingly: `queryItems` are converted into key-value pairs and appended onto the `path`, etc.
    * The `snaps` entry above results in an HTTP `GET` to `https://httpbin.org/response-headers?foo=1&bar=2&baz=3`. In addition, Kombucha always sends an `Accept` header of `application/json`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The top level of the configuration file looks like this:
   ...
   "snaps": [
     {
-      "body": { ... }
+      "body": { ... },
       "host": "httpbin.org",
       "httpMethod": "GET",
       "httpHeaders": {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ The top level of the configuration file looks like this:
   ...
   "snaps": [
     {
+      "body": { ... }
       "host": "httpbin.org",
+      "httpMethod": "GET",
+      "httpHeaders": {
+        "Accept-Language": "en-US"  
+      },
       "path": "/response-headers",
       "queryItems": {
         "foo": "1",
@@ -45,14 +50,16 @@ The top level of the configuration file looks like this:
       },
       "scheme": "https",
       "__snapName": "myUniqueSnapName",
-      "__snapType": "__GET"
+      "__snapType": "__REST""
     },
   ...
   ]
 }
 ```
 * The `snaps` entry needs to contain the `__snapName` key to uniquely identify the request. This name will be used to create a file with the snap result on disk.
-* `__snapType` specifies the type of request Kombucha is going to issue. `__GET` is a simple HTTP `GET` request, and the remaining parameters are interpreted accordingly: `queryItems` are converted into key-value pairs and appended onto the `path`, etc.
+* It is possible to specify any `HTTP` header field with `httpHeaders`  key, the value of a header needs to be a string. This key is requeried. Use `"httpHeaders": {}` to specify no headers.
+* The `body` key (not required) accepts arbitrary `JSON` and it will be used to set the body if the `HTTP` request.
+* `__snapType` specifies the type of request Kombucha is going to issue. `__REST"` is a simple HTTP `GET`, `POST`, `PUT`, `DELETE` or `PATCH` request (see the `httpMethod` key above), and the remaining parameters are interpreted accordingly: `queryItems` are converted into key-value pairs and appended onto the `path`, etc.
    * The `snaps` entry above results in an HTTP `GET` to `https://httpbin.org/response-headers?foo=1&bar=2&baz=3`. In addition, Kombucha always sends an `Accept` header of `application/json`.
 * Kombucha also supports a `__GRAPHQL` `__snapType` for testing GraphQL endpoints. Documentation for this is forthcoming. 😄
 
@@ -69,6 +76,10 @@ The user can add a `__preferences` blob to their configuration file to specify e
   "snaps": [
     {
       "host": "httpbin.org",
+      "httpMethod": "GET",
+      "httpHeaders": {
+        "Accept-Language": "en-US"  
+      },
       "path": "/response-headers",
       "queryItems": {},
       "scheme": "https",
@@ -88,7 +99,7 @@ The user can add a `__preferences` blob to their configuration file to specify e
         ]
       },
       "__snapName": "myUniqueSnapName",
-      "__snapType": "__GET"
+      "__snapType": "__REST"
     },
   ...
   ]
@@ -170,6 +181,8 @@ Kombucha performs this check recursively into nested JSON objects as deep as the
    * flag the values `"true"` and `"false"` (which should probably be `true` and `false` instead)
 * `string-numbers`
    * flag, for example, `"99.0"` (as opposed to `99.0`). This check should probably be used sparingly as there are plenty of pseudo-numeric values that nevertheless are best represented as strings (for example: opaque identifiers, or zip codes in the United States)
+* `strict-equality`
+    * ensure that the `JSON` from the response is exactly the same as the reference on disk.  
 
 ### Default checks
 

--- a/Sources/JSONCheck/JSONCheck.swift
+++ b/Sources/JSONCheck/JSONCheck.swift
@@ -183,8 +183,8 @@ private func checkForStrictEquality(context: JSONContext, _ reference: JSONValue
             return  [ .init(context: context, message: "Not a strict equality since arrays of different sizes: \(referenceArray.count) vs \(testArray.count)") ]
         }
         
-        return zip(referenceArray, testArray).enumerated().reduce(.empty) { previousChecks, acc in
-            let (index, (reference, test)) = acc
+        return zip(referenceArray, testArray).enumerated().reduce(.empty) { previousChecks, el in
+            let (index, (reference, test)) = el
             return previousChecks <> checkForStrictEquality(context: context.appending(.arrayIndex(index)), reference, test)
         }
         

--- a/Sources/JSONCheck/JSONCheck.swift
+++ b/Sources/JSONCheck/JSONCheck.swift
@@ -53,8 +53,8 @@ extension JSONCheck: Monoid where A: Monoid {
 ///
 /// - Parameters:
 ///   - context: a `JSONContext` describing the location in a larger JSON structure where this check is taking place
-///   - reference: a reference `JSONValue` (the snapshot)
-///   - test: a `JSONValue` to be tested
+///   - reference: a reference `JSONValue.object` (the snapshot)
+///   - test: a `JSONValue.object` to be tested
 /// - Returns: an array of `CheckResult` diagnostics
 private func checkMaps(context: JSONContext, _ reference: [String: JSONValue], _ test: [String: JSONValue]) -> [CheckResult] {
     return reference.reduce(.empty) { acc, rec in
@@ -150,6 +150,74 @@ private func checkTestArrayTypes(context: JSONContext, _ testArray: [JSONValue])
     }
 }
 
+/// compare two `JSONValue`s and return an array of `CheckResult`s flagging all differences between the `test` and `reference` value that would make the statement `reference == test` false based on the conformance of `JSONValue` to `Equatable`.
+///
+/// - Parameters:
+///   - context: a `JSONContext` describing the location in a larger JSON structure where this check is taking place
+///   - reference: a reference `JSONValue` (the snapshot)
+///   - test: a `JSONValue` to be tested
+/// - Returns: an array of `CheckResult` diagnostics
+private func checkForStrictEquality(context: JSONContext, _ reference: JSONValue, _ test: JSONValue) -> [CheckResult] {
+    
+    switch (reference, test) {
+    case (.bool(let refBool), .bool(let testBool)):
+        guard refBool != testBool else { return .empty }
+        return [ .init(context: context, message: "Not a strict equality between the boolean \(refBool) and \(testBool)") ]
+        
+    case (.double(let refDouble), .double(let testDouble)):
+        guard refDouble != testDouble else { return .empty }
+        return [ .init(context: context, message: "Not a strict equality between the number \(refDouble) and \(testDouble)") ]
+        
+    case (.null, .null):
+        return .empty
+        
+    case (.string(let refString), .string(let testString)):
+        guard refString != testString else { return .empty }
+        return [ .init(context: context, message: "Not a strict equality between the string \"\(refString)\" and \"\(testString)\"") ]
+        
+    case (.object(let referenceObject), .object(let testObject)):
+        return checkForStrictEqualityOfObjects(context: context, referenceObject, testObject)
+        
+    case (.array(let referenceArray), .array(let testArray)):
+        guard referenceArray.count == testArray.count else {
+            return  [ .init(context: context, message: "Not a strict equality since arrays of different sizes: \(referenceArray.count) vs \(testArray.count)") ]
+        }
+        
+        return zip(referenceArray, testArray).enumerated().reduce(.empty) { previousChecks, acc in
+            let (index, (reference, test)) = acc
+            return previousChecks <> checkForStrictEquality(context: context.appending(.arrayIndex(index)), reference, test)
+        }
+        
+    default:
+        return  [ .init(context: context, message: "Not a strict equality since the types are diffrent. Reference: \(reference), test: \(test)") ]
+    }
+}
+
+/// compare two `JSONValue` objects (`Dictionary`s) and return an array of `CheckResult`s flagging all differences between the `test` and `reference` objects based on the `checkForStrictEquality` test.
+///
+/// - Parameters:
+///   - context: a `JSONContext` describing the location in a larger JSON structure where this check is taking place
+///   - reference: a reference `JSONValue.object` (the snapshot)
+///   - test: a `JSONValue.object` to be tested
+private func checkForStrictEqualityOfObjects(context: JSONContext, _ referenceObject: [String : JSONValue], _ testObject: [String : JSONValue]) -> [CheckResult] {
+    
+    let newKeyInTestObjectChecks: [CheckResult] = testObject
+        .keys
+        .compactMap { key in referenceObject[key] == nil ? CheckResult(context: context, message: "Not a strict equality since there is a new key \(key)") : nil }
+    
+    let missingKeysInTestObjectAndStrictEqualityAtSharedKeys: [CheckResult] = referenceObject.reduce(.empty) { acc, rec in
+        let (key, referenceValue) = rec
+        guard let testValue = testObject[key] else {
+            let check = CheckResult(context: context, message: "Not a strict equality since the key \(key) does not exist")
+            return acc <> [check]
+        }
+        let nextContext = context.appending(.objectIndex(key))
+        return acc <> checkForStrictEquality(context: nextContext, referenceValue, testValue)
+    }
+    
+    return newKeyInTestObjectChecks <> missingKeysInTestObjectAndStrictEqualityAtSharedKeys
+}
+
 public extension JSONCheck where A == [CheckResult] {
     static let structure = JSONCheck(run: checkStructure)
 
@@ -193,4 +261,6 @@ public extension JSONCheck where A == [CheckResult] {
             stringCase: { Double($1) != nil ? [.init(context: $0, message: "string number: “\($1)”")] : .empty }
         )
     }
+    
+    static let strictEquality = JSONCheck(run: checkForStrictEquality)
 }

--- a/Sources/KombuchaLib/KombuchaLib.swift
+++ b/Sources/KombuchaLib/KombuchaLib.swift
@@ -19,7 +19,8 @@ public extension JSONCheck where A == [CheckResult] {
         "flag-new-keys": JSONCheck.flagNewKeys,
         "string-bools": JSONCheck.stringBools,
         "string-numbers": JSONCheck.stringNumbers,
-        "structure": JSONCheck.structure
+        "structure": JSONCheck.structure,
+        "strict-equality": JSONCheck.strictEquality
     ]
 }
 

--- a/Sources/KombuchaLib/SnapConfiguration+Network.swift
+++ b/Sources/KombuchaLib/SnapConfiguration+Network.swift
@@ -27,7 +27,11 @@ public extension SnapConfiguration {
         case .rest(let restSnap):
             var request = URLRequest(url: try restSnap.toURL().value)
             request.httpMethod = restSnap.httpMethod.rawValue
-            for (key, header) in restSnap.httpHeaders { request.setValue(header, forHTTPHeaderField: key) }
+            
+            if let httpHeaders = restSnap.httpHeaders {
+                for (key, header) in httpHeaders { request.setValue(header, forHTTPHeaderField: key) }
+            }
+            
             if let body = restSnap.body { request.httpBody = try encoder.encode(body) }
             return request
         case .graphQL(let graphQLSnap):

--- a/Sources/KombuchaLib/SnapConfiguration+Network.swift
+++ b/Sources/KombuchaLib/SnapConfiguration+Network.swift
@@ -26,7 +26,7 @@ public extension SnapConfiguration {
         switch request {
         case .rest(let restSnap):
             var request = URLRequest(url: try restSnap.toURL().value)
-            request.httpMethod = restSnap.httpMethod.rawValue
+            request.httpMethod = restSnap.httpMethod
             
             if let httpHeaders = restSnap.httpHeaders {
                 for (key, header) in httpHeaders { request.setValue(header, forHTTPHeaderField: key) }

--- a/Sources/KombuchaLib/SnapConfiguration+Network.swift
+++ b/Sources/KombuchaLib/SnapConfiguration+Network.swift
@@ -24,8 +24,12 @@ public extension SnapConfiguration {
 
     func toURLRequest(encoder: JSONEncoder) throws -> URLRequest {
         switch request {
-        case .get(let getSnap):
-            return .init(url: try getSnap.toURL().value)
+        case .rest(let restSnap):
+            var request = URLRequest(url: try restSnap.toURL().value)
+            request.httpMethod = restSnap.httpMethod.rawValue
+            for (key, header) in restSnap.httpHeaders { request.setValue(header, forHTTPHeaderField: key) }
+            if let body = restSnap.body { request.httpBody = try encoder.encode(body) }
+            return request
         case .graphQL(let graphQLSnap):
             var request = URLRequest(url: try graphQLSnap.toURL().value)
             request.httpBody = try encoder.encode(try EncodableGraphQLQueryContent(graphQLSnap.queryContent))

--- a/Sources/KombuchaLib/SnapConfiguration.swift
+++ b/Sources/KombuchaLib/SnapConfiguration.swift
@@ -67,7 +67,7 @@ extension SnapConfiguration.Request: CustomStringConvertible {
             let headerCount = restSnap.httpHeaders?.count ?? 0
             let hasBody = restSnap.body != nil
             return """
-            \(restSnap.httpMethod.rawValue): \(restSnap.host)\(restSnap.path)
+            \(restSnap.httpMethod): \(restSnap.host)\(restSnap.path)
             - \(queryCount) query \(queryCount <= 1 ? "param" : "params")
             - \(headerCount) http \(headerCount <= 1 ? "header" : "headers")
             - \(hasBody ? "resquest has a body" : "empty body")
@@ -108,19 +108,11 @@ extension SnapConfiguration.Request: Decodable {
 
 public struct RESTSnap: Decodable {
     
-    public enum HTTPMethod: String, Decodable {
-        case get = "GET"
-        case post = "POST"
-        case put = "PUT"
-        case delete = "DELETE"
-        case patch = "PATCH"
-    }
-    
     public var host: String
     public var path: String
     public var queryItems: [String: String?]
     public var scheme: String
-    public var httpMethod: HTTPMethod
+    public var httpMethod: String
     public var httpHeaders: [String: String?]?
     public var body: JSONValue?
 

--- a/Sources/KombuchaLib/SnapConfiguration.swift
+++ b/Sources/KombuchaLib/SnapConfiguration.swift
@@ -63,8 +63,15 @@ extension SnapConfiguration.Request: CustomStringConvertible {
     public var description: String {
         switch self {
         case .rest(let restSnap):
-            let count = restSnap.queryItems.count
-            return "\(restSnap.httpMethod.rawValue): \(restSnap.host)\(restSnap.path) - (\(count) query \(count == 1 ? "param" : "params"))"
+            let queryCount = restSnap.queryItems.count
+            let headerCount = restSnap.httpHeaders.count
+            let hasBody = restSnap.body != nil
+            return """
+            \(restSnap.httpMethod.rawValue): \(restSnap.host)\(restSnap.path)
+            - \(queryCount) query \(queryCount <= 1 ? "param" : "params")
+            - \(headerCount) http \(headerCount <= 1 ? "header" : "headers")
+            - \(hasBody ? "resquest has a body" : "empty body")
+            """
         case .graphQL(let graphSnap):
             return "GRAPHQL: \(graphSnap.host)\(graphSnap.path)"
         }

--- a/Sources/KombuchaLib/SnapConfiguration.swift
+++ b/Sources/KombuchaLib/SnapConfiguration.swift
@@ -64,7 +64,7 @@ extension SnapConfiguration.Request: CustomStringConvertible {
         switch self {
         case .rest(let restSnap):
             let queryCount = restSnap.queryItems.count
-            let headerCount = restSnap.httpHeaders.count
+            let headerCount = restSnap.httpHeaders?.count ?? 0
             let hasBody = restSnap.body != nil
             return """
             \(restSnap.httpMethod.rawValue): \(restSnap.host)\(restSnap.path)
@@ -121,7 +121,7 @@ public struct RESTSnap: Decodable {
     public var queryItems: [String: String?]
     public var scheme: String
     public var httpMethod: HTTPMethod
-    public var httpHeaders: [String: String?]
+    public var httpHeaders: [String: String?]?
     public var body: JSONValue?
 
     fileprivate static let snapTypeName = "__REST"

--- a/sample.json
+++ b/sample.json
@@ -3,22 +3,28 @@
   "snaps": [
     {
       "host": "httpbin.org",
+      "httpMethod": "GET",
+      "httpHeaders": {},
       "path": "/headers",
       "queryItems": {},
       "scheme": "https",
       "__snapName": "headersSnap",
-      "__snapType": "__GET"
+      "__snapType": "__REST"
     },
     {
       "host": "httpbin.org",
+      "httpMethod": "GET",
+      "httpHeaders": {},
       "path": "/ip",
       "queryItems": {},
       "scheme": "https",
       "__snapName": "ipSnap",
-      "__snapType": "__GET"
+      "__snapType": "__REST"
     },
     {
       "host": "httpbin.org",
+      "httpMethod": "GET",
+      "httpHeaders": {},
       "path": "/response-headers",
       "queryItems": {
         "foo": "1",
@@ -27,10 +33,12 @@
       },
       "scheme": "https",
       "__snapName": "responseHeadersSnap",
-      "__snapType": "__GET"
+      "__snapType": "__REST"
     },
     {
       "host": "httpbin.org",
+      "httpMethod": "GET",
+      "httpHeaders": {},
       "path": "/user-agent",
       "queryItems": {},
       "scheme": "https",
@@ -42,13 +50,14 @@
           "flag-new-keys",
           "string-bools",
           "string-numbers",
-          "structure"
+          "structure",
+          "strict-equality"
         ],
         "infos": [],
         "warnings": []
       },
       "__snapName": "userAagentSnap",
-      "__snapType": "__GET"
+      "__snapType": "__REST"
     }
   ]
 }

--- a/sample.json
+++ b/sample.json
@@ -4,7 +4,6 @@
     {
       "host": "httpbin.org",
       "httpMethod": "GET",
-      "httpHeaders": {},
       "path": "/headers",
       "queryItems": {},
       "scheme": "https",
@@ -14,7 +13,6 @@
     {
       "host": "httpbin.org",
       "httpMethod": "GET",
-      "httpHeaders": {},
       "path": "/ip",
       "queryItems": {},
       "scheme": "https",
@@ -24,7 +22,9 @@
     {
       "host": "httpbin.org",
       "httpMethod": "GET",
-      "httpHeaders": {},
+      "httpHeaders": {
+          "testHeader": "test"
+      },
       "path": "/response-headers",
       "queryItems": {
         "foo": "1",
@@ -38,7 +38,6 @@
     {
       "host": "httpbin.org",
       "httpMethod": "GET",
-      "httpHeaders": {},
       "path": "/user-agent",
       "queryItems": {},
       "scheme": "https",


### PR DESCRIPTION
* Add `POST`, `PUT`, `DELETE`  and `PATCH` support for `REST API` calls
* Add support for `Headers` and `Body` in standard REST calls.  
* Add a test to support strict equality between JSON files.