### PR TITLE
Bump base Swift image to 5.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.0.1-bionic
+FROM swift:5.0.2
 
 # Create app directory
 WORKDIR /app


### PR DESCRIPTION
Fixes a bug with Swift which was preventing certain API authorization challenges from working in Linux: https://github.com/apple/swift-corelibs-foundation/pull/2255